### PR TITLE
Reset Offset on Text Change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,16 @@ const Marquee = React.createClass({
     clearTimeout(this._marqueeTimer);
   },
 
+  componentWillReceiveProps(nextProps) {
+          if(this.props.text.length != nextProps.text.length)
+          {
+              clearTimeout(this._marqueeTimer);
+              this.setState({
+                animatedWidth: 0
+              });
+          }
+  },
+
   handleMouseEnter() {
     if (this.props.hoverToStop) {
       clearTimeout(this._marqueeTimer);


### PR DESCRIPTION
Fixed an Issue of Offset not being resetting on Text Change.
Steps to Reproduce : 
1.Set a large text and let it Scroll.
2.Change the Text 

Actual Result : The Offset of Marquee Label is not reset to 0.
Expected Result : Offset should be reset to 0.

Added Check for Text Length Changed & Reset offset in WillRecieveProps()