### PR TITLE
Loosen semver ranges for react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "babel-preset-stage-0": "^6.5.0"
   },
   "peerDependencies": {
-    "react": "~0.14.0 || ~15.0.0 || ~16.0.0",
-    "react-dom": "~0.14.0 || ~15.0.0 || ~16.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "prop-types": "*"


### PR DESCRIPTION
The current semver ranges are quite strict, for example, they only match React `16.0.x`, rather than `16.x.x`.

With the latest React installed (16.7), npm shows warnings:

```
npm WARN react-marquee@1.0.0 requires a peer of react@~0.14.0 || ~15.0.0 || ~16.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN react-marquee@1.0.0 requires a peer of react-dom@~0.14.0 || ~15.0.0 || ~16.0.0 but none is installed. You must install peer dependencies yourself.
```