### PR TITLE
Added `title` prop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,7 @@ var Marquee = function (_Component) {
             onMouseLeave: this.handleMouseLeave },
           _react2.default.createElement(
             'span',
-            { ref: 'text', style: style, title: this.props.text },
+            { ref: 'text', style: style, title: this.props.title || this.props.text },
             this.props.text
           )
         );
@@ -201,7 +201,8 @@ Marquee.defaultProps = {
   hoverToStop: false,
   loop: false,
   leading: 0,
-  trailing: 0
+  trailing: 0,
+  title: ''
 };
 
 Marquee.propTypes = {
@@ -210,7 +211,8 @@ Marquee.propTypes = {
   loop: _propTypes2.default.bool,
   leading: _propTypes2.default.number,
   trailing: _propTypes2.default.number,
-  className: _propTypes2.default.string
+  className: _propTypes2.default.string,
+  title: _propTypes2.default.string
 };
 
 module.exports = Marquee;

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ class Marquee extends Component {
         <div className={`ui-marquee ${this.props.className}`} style={{overflow: 'hidden'}}
              onMouseEnter={this.handleMouseEnter}
              onMouseLeave={this.handleMouseLeave}>
-          <span ref="text" style={style} title={this.props.text}>{this.props.text}</span>
+          <span ref="text" style={style} title={this.props.title || this.props.text}>{this.props.text}</span>
         </div>
       );
     }
@@ -157,7 +157,8 @@ Marquee.defaultProps = {
   hoverToStop: false,
   loop: false,
   leading: 0,
-  trailing: 0
+  trailing: 0,
+  title: ''
 }
 
 Marquee.propTypes = {
@@ -166,7 +167,8 @@ Marquee.propTypes = {
   loop: PropTypes.bool,
   leading: PropTypes.number,
   trailing: PropTypes.number,
-  className: PropTypes.string
+  className: PropTypes.string,
+  title: PropTypes.string
 }
 
 module.exports = Marquee;


### PR DESCRIPTION
When you pass a complex jsx snippet for the text, the tooltip will render as `[object Object]`: 
![image](https://user-images.githubusercontent.com/13560711/61228206-b8ede780-a71d-11e9-90b0-fc23e1f81e32.png)
This PR allows you to pass your own `title` property to the component. The default behaviour is still the same.